### PR TITLE
valueProp other than value bug solving

### DIFF
--- a/src.js
+++ b/src.js
@@ -147,7 +147,7 @@ class Validation extends Component {
             this.baseProps[this.props.valueProp] = props.children.props[this.props.valueProp];
             this.currentChildValue = props.children.props[this.props.valueProp];
             freshRendered = true;
-            this.testValidity(props.children.props.value);
+            this.testValidity(this.currentChildValue);
           }
         }
       }


### PR DESCRIPTION
The call was not the right either use props.children.props[this.props.valueProp] or directly this.currentChildValue